### PR TITLE
"Standard" filter on Tracker tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
     <div class="col-xs-8">
       <ul id="filtersLeft">
 	    <li><a>All</a></li>
+	    <li><a>Standard</a></li>
 	    <li><a>Classic</a></li>
 	    <li><a>Naxxramas</a></li>
 	    <li><a>GvG</a></li>


### PR DESCRIPTION
This adds a "Standard" filter button on Tracker tab. Partially addresses #47. Preview here: http://leonix.github.io/hs-collection-tracker/

I managed to implement this without much pain. I did not add any pseudo-sets. In fact, no global vars are affected. Filtering is done on-the-fly using existing data structures.

Same approach didn't work for Progress tab, though. No idea how to handle that.

I'm not sure if this PL should be merged as is. That's up to Freezard. I use it myself and find it better than nothing. It's posted here in hope that it may be somehow useful for real actual filter implementation in future.
